### PR TITLE
Add an optional package name parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,10 +228,11 @@ There's still a lot to do! Looking for contributors to address any of above.
 # Usage Tips
 
 1. All macros support arguments ```debug=true``` and ```outPath="..."```. ```debug``` causes the generated 
-code to be dumped to stdout, and ```outPath``` causes the generated code to be written to a file.
+code to be dumped to stdout, and ```outPath``` causes the generated code to be written to a file. 
+The optional argument ```outPathPackage``` allows to specify a package name for the output file.
  
     ```scala
-    @fromSchemaResource("/simple.json", debug=true, outPath="/tmp/Simple.Scala")
+    @fromSchemaResource("/simple.json", debug=true, outPath="/tmp/Simple.Scala", outPathPackage="argus.simple")
     object Test
     ```
 

--- a/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
+++ b/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
@@ -386,6 +386,18 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
     lines.size should be >= 10
   }
 
+  it should "support outPath with a package name and write out the generated code" in {
+    @fromSchemaResource("/simple.json", outPath=Some("/tmp/SimplePackage.scala"), outPathPackage = Some("org.argus.simple"))
+    object Simple
+
+    val file = new File("/tmp/SimplePackage.scala")
+    file should exist
+
+    val lines = Source.fromFile(file).getLines.toList
+    lines.head should === ("package org.argus.simple;")
+    lines.size should be >= 10
+  }
+
   it should "support name, and name the root element using it" in {
     @fromSchemaResource("/simple.json", name="Person")
     object Schema


### PR DESCRIPTION
In some cases it could be useful to specify a package name on the output file generated with the outPath parameter.