### PR TITLE
Support format

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ case class Root(name: String, age: Option[Int] = None)
 </tr>
 </table>
 
+### Basic types
+<table>
+<tr><td>json type</td><td>json format</td><td>Generated Scala type</td>
+<tr><td><pre>string</pre></td><td><pre>*</pre></td><td><pre>String</pre></td></tr>
+<tr><td><pre>integer</pre></td><td><pre>* | int32</pre></td><td><pre>Int</pre></td></tr>
+<tr><td><pre>integer</pre></td><td><pre>int64</pre></td><td><pre>Long</pre></td></tr>
+<tr><td><pre>integer</pre></td><td><pre>int16</pre></td><td><pre>Short</pre></td></tr>
+<tr><td><pre>integer</pre></td><td><pre>int8</pre></td><td><pre>Byte</pre></td></tr>
+<tr><td><pre>number</pre></td><td><pre>* | double</pre></td><td><pre>Double</pre></td></tr>
+<tr><td><pre>number</pre></td><td><pre>single</pre></td><td><pre>Float</pre></td></tr>
+<tr><td><pre>boolean</pre></td><td><pre>*</pre></td><td><pre>Boolean</pre></td></tr>
+<tr><td><pre>null</pre></td><td><pre>*</pre></td><td><pre>Null</pre></td></tr>
+</table>
+
 ### Definitions (i.e. common class definitions)
 <table>
 <tr><td>Json</td><td>Generated Scala</td>

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ case class Root(name: String, age: Option[Int] = None)
 <tr><td>json type</td><td>json format</td><td>Generated Scala type</td>
 <tr><td><pre>string</pre></td><td><pre>*</pre></td><td><pre>String</pre></td></tr>
 <tr><td><pre>string</pre></td><td><pre>uuid</pre></td><td><pre>java.util.UUID</pre></td></tr>
+<tr><td><pre>string</pre></td><td><pre>date-time</pre></td><td><pre>org.joda.time.DateTime</pre></td></tr>
 <tr><td><pre>integer</pre></td><td><pre>* | int32</pre></td><td><pre>Int</pre></td></tr>
 <tr><td><pre>integer</pre></td><td><pre>int64</pre></td><td><pre>Long</pre></td></tr>
 <tr><td><pre>integer</pre></td><td><pre>int16</pre></td><td><pre>Short</pre></td></tr>

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ case class Root(name: String, age: Option[Int] = None)
 <table>
 <tr><td>json type</td><td>json format</td><td>Generated Scala type</td>
 <tr><td><pre>string</pre></td><td><pre>*</pre></td><td><pre>String</pre></td></tr>
+<tr><td><pre>string</pre></td><td><pre>uuid</pre></td><td><pre>java.util.UUID</pre></td></tr>
 <tr><td><pre>integer</pre></td><td><pre>* | int32</pre></td><td><pre>Int</pre></td></tr>
 <tr><td><pre>integer</pre></td><td><pre>int64</pre></td><td><pre>Long</pre></td></tr>
 <tr><td><pre>integer</pre></td><td><pre>int16</pre></td><td><pre>Short</pre></td></tr>

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ case class Root(name: String, age: Option[Int] = None)
 <tr><td>json type</td><td>json format</td><td>Generated Scala type</td>
 <tr><td><pre>string</pre></td><td><pre>*</pre></td><td><pre>String</pre></td></tr>
 <tr><td><pre>string</pre></td><td><pre>uuid</pre></td><td><pre>java.util.UUID</pre></td></tr>
-<tr><td><pre>string</pre></td><td><pre>date-time</pre></td><td><pre>org.joda.time.DateTime</pre></td></tr>
+<tr><td><pre>string</pre></td><td><pre>date-time</pre></td><td><pre>java.time.ZonedDateTime</pre></td></tr>
 <tr><td><pre>integer</pre></td><td><pre>* | int32</pre></td><td><pre>Int</pre></td></tr>
 <tr><td><pre>integer</pre></td><td><pre>int64</pre></td><td><pre>Long</pre></td></tr>
 <tr><td><pre>integer</pre></td><td><pre>int16</pre></td><td><pre>Short</pre></td></tr>

--- a/argus/src/main/scala/argus/macros/CirceCodecBuilder.scala
+++ b/argus/src/main/scala/argus/macros/CirceCodecBuilder.scala
@@ -14,13 +14,14 @@ class CirceCodecBuilder[U <: Universe](val u: U) extends CodecBuilder {
     q"import cats.syntax.either._" ::
     q"import io.circe._" ::
     q"import io.circe.syntax._" ::
+    q"import io.circe.java8.time._" ::
     Nil
 
   def inEncoder(typ: Tree) = tq"Encoder[$typ]"
 
   def inDecoder(typ: Tree) = tq"Decoder[$typ]"
 
-  def constants = anyEncoder :: anyDecoder :: dateTimeEncoder :: dateTimeDecoder :: Nil
+  def constants = anyEncoder :: anyDecoder :: Nil
 
   val anyEncoder = q"""
     def anyEncoder: Encoder[Any] = Encoder.instance((a: Any) => a match {
@@ -56,24 +57,6 @@ class CirceCodecBuilder[U <: Universe](val u: U) extends CodecBuilder {
       case o if o.isObject =>  o.as[Map[String, Any]](Decoder.decodeMapLike(KeyDecoder.decodeKeyString, anyDecoder, Map.canBuildFrom))
       case a if a.isArray =>   a.as[List[Any]](Decoder.decodeCanBuildFrom(anyDecoder, List.canBuildFrom[Any]))
     })
-  """
-
-  val dateTimeEncoder = q"""
-    implicit val dateTimeEncoder: Encoder[org.joda.time.DateTime] = Encoder.instance(dt => dt.toString(org.joda.time.format.ISODateTimeFormat.dateTime().withOffsetParsed).asJson);
-  """
-
-  val dateTimeDecoder = q"""
-    implicit val dateTimeDecoder: Decoder[org.joda.time.DateTime] = Decoder.instance((c: HCursor) =>
-      for {
-        json <- c.as[Json]
-        strJson <- json.asString.map(Either.right).getOrElse(Either.left(DecodingFailure("DateTime", c.history)))
-        dt <- try {
-          Either.right(org.joda.time.DateTime.parse(json.asString.get, org.joda.time.format.ISODateTimeFormat.dateTime().withOffsetParsed))
-        } catch {
-          case error: Exception => Either.left(DecodingFailure(error.getMessage, c.history))
-        }
-      } yield dt
-    )
   """
 
   def mkAnyWrapperEncoder(typ: Tree) = q"""

--- a/argus/src/main/scala/argus/macros/CirceCodecBuilder.scala
+++ b/argus/src/main/scala/argus/macros/CirceCodecBuilder.scala
@@ -20,7 +20,7 @@ class CirceCodecBuilder[U <: Universe](val u: U) extends CodecBuilder {
 
   def inDecoder(typ: Tree) = tq"Decoder[$typ]"
 
-  def constants = anyEncoder :: anyDecoder :: Nil
+  def constants = anyEncoder :: anyDecoder :: dateTimeEncoder :: dateTimeDecoder :: Nil
 
   val anyEncoder = q"""
     def anyEncoder: Encoder[Any] = Encoder.instance((a: Any) => a match {
@@ -56,6 +56,24 @@ class CirceCodecBuilder[U <: Universe](val u: U) extends CodecBuilder {
       case o if o.isObject =>  o.as[Map[String, Any]](Decoder.decodeMapLike(KeyDecoder.decodeKeyString, anyDecoder, Map.canBuildFrom))
       case a if a.isArray =>   a.as[List[Any]](Decoder.decodeCanBuildFrom(anyDecoder, List.canBuildFrom[Any]))
     })
+  """
+
+  val dateTimeEncoder = q"""
+    implicit val dateTimeEncoder: Encoder[org.joda.time.DateTime] = Encoder.instance(dt => dt.toString(org.joda.time.format.ISODateTimeFormat.dateTime().withOffsetParsed).asJson);
+  """
+
+  val dateTimeDecoder = q"""
+    implicit val dateTimeDecoder: Decoder[org.joda.time.DateTime] = Decoder.instance((c: HCursor) =>
+      for {
+        json <- c.as[Json]
+        strJson <- json.asString.map(Either.right).getOrElse(Either.left(DecodingFailure("DateTime", c.history)))
+        dt <- try {
+          Either.right(org.joda.time.DateTime.parse(json.asString.get, org.joda.time.format.ISODateTimeFormat.dateTime().withOffsetParsed))
+        } catch {
+          case error: Exception => Either.left(DecodingFailure(error.getMessage, c.history))
+        }
+      } yield dt
+    )
   """
 
   def mkAnyWrapperEncoder(typ: Tree) = q"""

--- a/argus/src/main/scala/argus/macros/CirceCodecBuilder.scala
+++ b/argus/src/main/scala/argus/macros/CirceCodecBuilder.scala
@@ -33,6 +33,7 @@ class CirceCodecBuilder[U <: Universe](val u: U) extends CodecBuilder {
       case f: Float =>    f.asJson
       case d: Double =>   d.asJson
       case s: String =>   s.asJson
+      case u: java.util.UUID => u.asJson
       case a: Array[Boolean] @unchecked => a.asJson
       case a: Array[Byte]    @unchecked => a.asJson
       case a: Array[Short]   @unchecked => a.asJson

--- a/argus/src/main/scala/argus/macros/ModelBuilder.scala
+++ b/argus/src/main/scala/argus/macros/ModelBuilder.scala
@@ -34,6 +34,7 @@ class ModelBuilder[U <: Universe](val u: U) {
     case (SimpleTypes.Number, Some(Formats.Single)) => tq"Float"
     case (SimpleTypes.Number, _) => tq"Double"
     case (SimpleTypes.String, Some(Formats.Uuid)) => tq"java.util.UUID"
+    case (SimpleTypes.String, Some(Formats.DateTime)) => tq"org.joda.time.DateTime"
     case (SimpleTypes.String, _) => tq"String"
     case (SimpleTypes.Null, _) => tq"Null"
     case _ => throw new Exception("Type isn't a known intrinsic type " + st)

--- a/argus/src/main/scala/argus/macros/ModelBuilder.scala
+++ b/argus/src/main/scala/argus/macros/ModelBuilder.scala
@@ -34,7 +34,7 @@ class ModelBuilder[U <: Universe](val u: U) {
     case (SimpleTypes.Number, Some(Formats.Single)) => tq"Float"
     case (SimpleTypes.Number, _) => tq"Double"
     case (SimpleTypes.String, Some(Formats.Uuid)) => tq"java.util.UUID"
-    case (SimpleTypes.String, Some(Formats.DateTime)) => tq"org.joda.time.DateTime"
+    case (SimpleTypes.String, Some(Formats.DateTime)) => tq"java.time.ZonedDateTime"
     case (SimpleTypes.String, _) => tq"String"
     case (SimpleTypes.Null, _) => tq"Null"
     case _ => throw new Exception("Type isn't a known intrinsic type " + st)

--- a/argus/src/main/scala/argus/macros/ModelBuilder.scala
+++ b/argus/src/main/scala/argus/macros/ModelBuilder.scala
@@ -33,6 +33,7 @@ class ModelBuilder[U <: Universe](val u: U) {
     case (SimpleTypes.Integer, _)  => tq"Int"
     case (SimpleTypes.Number, Some(Formats.Single)) => tq"Float"
     case (SimpleTypes.Number, _) => tq"Double"
+    case (SimpleTypes.String, Some(Formats.Uuid)) => tq"java.util.UUID"
     case (SimpleTypes.String, _) => tq"String"
     case (SimpleTypes.Null, _) => tq"Null"
     case _ => throw new Exception("Type isn't a known intrinsic type " + st)

--- a/argus/src/main/scala/argus/macros/ModelBuilder.scala
+++ b/argus/src/main/scala/argus/macros/ModelBuilder.scala
@@ -22,14 +22,19 @@ class ModelBuilder[U <: Universe](val u: U) {
     SimpleTypes.Integer :: SimpleTypes.Null :: Nil
 
   /**
-    * Make a type from a SimpleType, when st is a built in type (i.e. Boolean, Int, Double, String, or Null)
+    * Make a type from a SimpleType and an optional Format, when st is a built in type (i.e. Boolean, Int, Double,
+    * String, or Null)
     */
-  def mkIntrinsicType(st: SimpleType): Tree = st match {
-    case SimpleTypes.Boolean => tq"Boolean"
-    case SimpleTypes.Integer => tq"Int"
-    case SimpleTypes.Number => tq"Double"
-    case SimpleTypes.String => tq"String"
-    case SimpleTypes.Null => tq"Null"
+  def mkIntrinsicType(st: SimpleType, format: Option[Format]): Tree = (st,format) match {
+    case (SimpleTypes.Boolean, _) => tq"Boolean"
+    case (SimpleTypes.Integer, Some(Formats.Int64)) => tq"Long"
+    case (SimpleTypes.Integer, Some(Formats.Int16)) => tq"Short"
+    case (SimpleTypes.Integer, Some(Formats.Int8)) => tq"Byte"
+    case (SimpleTypes.Integer, _)  => tq"Int"
+    case (SimpleTypes.Number, Some(Formats.Single)) => tq"Float"
+    case (SimpleTypes.Number, _) => tq"Double"
+    case (SimpleTypes.String, _) => tq"String"
+    case (SimpleTypes.Null, _) => tq"Null"
     case _ => throw new Exception("Type isn't a known intrinsic type " + st)
   }
 
@@ -157,7 +162,7 @@ class ModelBuilder[U <: Universe](val u: U) {
 
       // Alias to an intrinsic type
       case (_,_,Some(SimpleTypeTyp(st: SimpleType)),_,_) if IntrinsicType.contains(st) => {
-        mkTypeAlias(path, name, mkIntrinsicType(st))
+        mkTypeAlias(path, name, mkIntrinsicType(st, schema.format))
       }
 
       // OneOfs (aka Union types)
@@ -229,7 +234,7 @@ class ModelBuilder[U <: Universe](val u: U) {
 
       // Make intrinsic type reference
       case (Some(SimpleTypeTyp(st: SimpleType)),_,_,_,_) if IntrinsicType.contains(st) => {
-        (mkIntrinsicType(st), defDefs)
+        (mkIntrinsicType(st, schema.format), defDefs)
       }
 
       // If it contains inline definitions, then delegate to mkSchema, and name type after the parameter name.

--- a/argus/src/main/scala/argus/schema/Schema.scala
+++ b/argus/src/main/scala/argus/schema/Schema.scala
@@ -255,6 +255,7 @@ object Schema {
     case object Double extends Format { val name = "double" }
     case object Single extends Format { val name = "single" }
     case object Uuid extends Format { val name = "uuid" }
+    case object DateTime extends Format { val name = "date-time" }
   }
 
   implicit def FormatDecoder: Decoder[Format] =
@@ -268,6 +269,7 @@ object Schema {
         case "double" => Either.right(Formats.Double)
         case "single" => Either.right(Formats.Single)
         case "uuid" => Either.right(Formats.Uuid)
+        case "date-time" => Either.right(Formats.DateTime)
         case t@_ => Either.right(Formats.Unknown)
       }
     } yield format)

--- a/argus/src/main/scala/argus/schema/Schema.scala
+++ b/argus/src/main/scala/argus/schema/Schema.scala
@@ -254,6 +254,7 @@ object Schema {
     case object Int8 extends Format { val name = "int8" }
     case object Double extends Format { val name = "double" }
     case object Single extends Format { val name = "single" }
+    case object Uuid extends Format { val name = "uuid" }
   }
 
   implicit def FormatDecoder: Decoder[Format] =
@@ -266,6 +267,7 @@ object Schema {
         case "int8" => Either.right(Formats.Int8)
         case "double" => Either.right(Formats.Double)
         case "single" => Either.right(Formats.Single)
+        case "uuid" => Either.right(Formats.Uuid)
         case t@_ => Either.right(Formats.Unknown)
       }
     } yield format)

--- a/argus/src/test/scala/argus/macros/CirceCodecBuilderSpec.scala
+++ b/argus/src/test/scala/argus/macros/CirceCodecBuilderSpec.scala
@@ -64,9 +64,9 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
   "mkUnionEncoder()" should "make encoders for a given @union set" in {
     val union =
       (tq"Int", tq"FooInt") ::
-      (tq"String", tq"Root.FooString") ::
-      (tq"Bar.Person", tq"FooBarPerson") ::
-      Nil
+        (tq"String", tq"Root.FooString") ::
+        (tq"Bar.Person", tq"FooBarPerson") ::
+        Nil
 
     val res = codecBuilder.mkUnionEncoder(tq"Foo", union)
 
@@ -82,9 +82,9 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
   "mkUnionDecoder()" should "make decoders for a given @union set" in {
     val union =
       (tq"Int", tq"FooInt") ::
-      (tq"String", tq"Root.FooString") ::
-      (tq"Bar.Person", tq"FooBarPerson") ::
-      Nil
+        (tq"String", tq"Root.FooString") ::
+        (tq"Bar.Person", tq"FooBarPerson") ::
+        Nil
 
     val res = codecBuilder.mkUnionDecoder(tq"Foo", union)
 
@@ -100,8 +100,8 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
   "mkEnumEncoder()" should "make encoders for a given @enum set" in {
     val enums =
       ("1", tq"Foo1") ::
-      ("\"NZ\"", tq"FooNZ") ::
-      Nil
+        ("\"NZ\"", tq"FooNZ") ::
+        Nil
 
     val res = codecBuilder.mkEnumEncoder(tq"Foo", enums)
     res should === (q"""
@@ -112,8 +112,8 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
   "mkEnumDecoder()" should "make decoders for a given @enum set" in {
     val pairs =
       ("1", q"FooEnum.Foo1") ::
-      ("\"NZ\"", q"FooEnum.FooNZ") ::
-      Nil
+        ("\"NZ\"", q"FooEnum.FooNZ") ::
+        Nil
 
     val res = codecBuilder.mkEnumDecoder(tq"Foo", pairs)
     res should === (q"""
@@ -131,49 +131,54 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
   "mkCodec()" should "make add an encoder/decoder for each case class" in {
     val defs =
       q"case class Foo(a: Int)" ::
-      q"case class Bar(b: Int, c: String)" ::
-      Nil
+        q"case class Bar(b: Int, c: String)" ::
+        Nil
 
     val res = codecBuilder.mkCodec(defs)
 
     res collect extractCodecNameAndType should contain theSameElementsAs
-      List(("FooEncoder","Encoder[Foo]"), ("FooDecoder","Decoder[Foo]"), ("BarEncoder","Encoder[Bar]"), ("BarDecoder","Decoder[Bar]"))
+      List(("dateTimeEncoder", "Encoder[org.joda.time.DateTime]"), ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]"),
+        ("FooEncoder","Encoder[Foo]"), ("FooDecoder","Decoder[Foo]"), ("BarEncoder","Encoder[Bar]"), ("BarDecoder","Decoder[Bar]"))
   }
 
   it should "ignore other definitions" in {
     val defs =
       q"val a = 1" ::
-      q"object A" ::
-      Nil
+        q"object A" ::
+        Nil
 
     val res = codecBuilder.mkCodec(defs) collect extractCodecNameAndType
-    res should be (empty)
+    res should contain theSameElementsAs List(("dateTimeEncoder", "Encoder[org.joda.time.DateTime]"),
+      ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]"))
   }
 
   it should "work with nested case classes" in {
     val defs = List(q"object Root { object Foo { case class Bar(a: Int) } }")
     val res = codecBuilder.mkCodec(defs)
     res collect extractCodecNameAndType should contain theSameElementsAs
-      List(("RootFooBarEncoder","Encoder[Root.Foo.Bar]"), ("RootFooBarDecoder","Decoder[Root.Foo.Bar]"))
+      List(("dateTimeEncoder", "Encoder[org.joda.time.DateTime]"), ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]"),
+        ("RootFooBarEncoder","Encoder[Root.Foo.Bar]"), ("RootFooBarDecoder","Decoder[Root.Foo.Bar]"))
   }
 
   it should "add an encoder/decoder for each @enum" in {
     val defs =
       q"@enum sealed trait Foo extends scala.Product with scala.Serializable { def json: String }" ::
-      q"""
+        q"""
         object FooEnum {
           case object Foo1 extends Foo { val json: String = "1" }
           case object FooNZ extends Foo { val json: String = "\"NZ\"" }
         }
       """ ::
-      Nil
+        Nil
 
     val res = codecBuilder.mkCodec(defs)
 
     res collect extractCodecNameAndType should contain theSameElementsAs
-      ("FooEncoder","Encoder[Foo]") ::
-      ("FooDecoder","Decoder[Foo]") ::
-      Nil
+      ("dateTimeEncoder", "Encoder[org.joda.time.DateTime]") ::
+        ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]") ::
+        ("FooEncoder","Encoder[Foo]") ::
+        ("FooDecoder","Decoder[Foo]") ::
+        Nil
 
     val code = res map(showCode(_)) mkString("")
     code should include("parse(\"1\")")
@@ -183,15 +188,17 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
   it should "add an encoder/decoder for each @union" in {
     val defs =
       q"@union sealed trait Foo extends scala.Product with scala.Serializable" ::
-      q"case class FooInt(x: Int) extends Foo" ::
-      q"case class FooBarPerson(x: bar.Person) extends Foo" ::
-      Nil
+        q"case class FooInt(x: Int) extends Foo" ::
+        q"case class FooBarPerson(x: bar.Person) extends Foo" ::
+        Nil
 
     val res = codecBuilder.mkCodec(defs)
     res collect extractCodecNameAndType should contain theSameElementsAs
-      ("FooEncoder","Encoder[Foo]") ::
-      ("FooDecoder","Decoder[Foo]") ::
-      Nil
+      ("dateTimeEncoder", "Encoder[org.joda.time.DateTime]") ::
+        ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]") ::
+        ("FooEncoder","Encoder[Foo]") ::
+        ("FooDecoder","Decoder[Foo]") ::
+        Nil
 
     val code = res map(showCode(_)) mkString("")
     code should include("FooBarPerson(x)")
@@ -201,8 +208,8 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
   it should "add an encoder/decoder for AnyWrapper types (and not for other types)" in {
     val defs =
       q"case class Foo(x: Any)" ::
-      q"case class Bar(x: Int)" ::
-      Nil
+        q"case class Bar(x: Int)" ::
+        Nil
 
     val res = codecBuilder.mkCodec(defs)
     res collect extractCodecNameAndType should contain allOf(

--- a/argus/src/test/scala/argus/macros/CirceCodecBuilderSpec.scala
+++ b/argus/src/test/scala/argus/macros/CirceCodecBuilderSpec.scala
@@ -137,8 +137,8 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
     val res = codecBuilder.mkCodec(defs)
 
     res collect extractCodecNameAndType should contain theSameElementsAs
-      List(("dateTimeEncoder", "Encoder[org.joda.time.DateTime]"), ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]"),
-        ("FooEncoder","Encoder[Foo]"), ("FooDecoder","Decoder[Foo]"), ("BarEncoder","Encoder[Bar]"), ("BarDecoder","Decoder[Bar]"))
+      List(("FooEncoder","Encoder[Foo]"), ("FooDecoder","Decoder[Foo]"), ("BarEncoder","Encoder[Bar]"),
+        ("BarDecoder","Decoder[Bar]"))
   }
 
   it should "ignore other definitions" in {
@@ -148,16 +148,14 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
         Nil
 
     val res = codecBuilder.mkCodec(defs) collect extractCodecNameAndType
-    res should contain theSameElementsAs List(("dateTimeEncoder", "Encoder[org.joda.time.DateTime]"),
-      ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]"))
+    res should contain theSameElementsAs Nil
   }
 
   it should "work with nested case classes" in {
     val defs = List(q"object Root { object Foo { case class Bar(a: Int) } }")
     val res = codecBuilder.mkCodec(defs)
     res collect extractCodecNameAndType should contain theSameElementsAs
-      List(("dateTimeEncoder", "Encoder[org.joda.time.DateTime]"), ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]"),
-        ("RootFooBarEncoder","Encoder[Root.Foo.Bar]"), ("RootFooBarDecoder","Decoder[Root.Foo.Bar]"))
+      List(("RootFooBarEncoder","Encoder[Root.Foo.Bar]"), ("RootFooBarDecoder","Decoder[Root.Foo.Bar]"))
   }
 
   it should "add an encoder/decoder for each @enum" in {
@@ -174,9 +172,7 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
     val res = codecBuilder.mkCodec(defs)
 
     res collect extractCodecNameAndType should contain theSameElementsAs
-      ("dateTimeEncoder", "Encoder[org.joda.time.DateTime]") ::
-        ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]") ::
-        ("FooEncoder","Encoder[Foo]") ::
+      ("FooEncoder","Encoder[Foo]") ::
         ("FooDecoder","Decoder[Foo]") ::
         Nil
 
@@ -194,9 +190,7 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
 
     val res = codecBuilder.mkCodec(defs)
     res collect extractCodecNameAndType should contain theSameElementsAs
-      ("dateTimeEncoder", "Encoder[org.joda.time.DateTime]") ::
-        ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]") ::
-        ("FooEncoder","Encoder[Foo]") ::
+      ("FooEncoder","Encoder[Foo]") ::
         ("FooDecoder","Decoder[Foo]") ::
         Nil
 

--- a/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
+++ b/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
@@ -9,6 +9,8 @@ import org.scalatest.{FlatSpec, Matchers}
 import cats.syntax.either._
 import io.circe._
 import io.circe.syntax._
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
 
 import scala.io.Source
 
@@ -308,6 +310,94 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
     val root = parser.decode[Root](json).toOption.get
 
     root.id should === (Some(UUID.fromString(uuid)))
+  }
+
+  it should "encode DateTime type" in {
+    @fromSchemaJson("""
+    {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+    """)
+    object Foo
+    import Foo._
+    import Foo.Implicits._
+    import io.circe.syntax._
+
+
+    val dateTime = "2017-01-01T10:00:00.000Z"
+    val uuid = "38400000-8cf0-11bd-b23e-10b96e4ef00d"
+    val root = Root(Some(DateTime.parse(dateTime)))
+    root.asJson should beSameJsonAs (s"""
+                                        |{
+                                        |  "createdAt": "$dateTime"
+                                        |}
+                                     """.stripMargin)
+  }
+
+  it should "decode DateTime type" in {
+    @fromSchemaJson("""
+    {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+    """)
+    object Foo
+    import Foo._
+    import Foo.Implicits._
+
+    val dateTime = "2017-01-01T10:00:00.000Z"
+    val json =
+      s"""
+         |{
+         |  "createdAt": "$dateTime"
+         |}
+      """.stripMargin
+    val root = parser.decode[Root](json).toOption.get
+
+    root.createdAt should === (Some(DateTime.parse(dateTime)))
+  }
+
+  it should "return an error on decoding for datetime with wrong format" in {
+    @fromSchemaJson("""
+    {
+      "type": "object",
+      "properties": {
+        "createdAt": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    }
+    """)
+    object Foo
+    import Foo._
+    import Foo.Implicits._
+
+    val dateTime = "wrongDateTime"
+    val json =
+      s"""
+         |{
+         |  "createdAt": "$dateTime"
+         |}
+      """.stripMargin
+    val root = parser.decode[Root](json)
+
+    root should be ('left)
+    root.left.get match {
+      case d: DecodingFailure => d.message should === ("Invalid format: \"wrongDateTime\"")
+      case e@_ => fail(s"Wrong error type: ${e.getClass.getName}")
+    }
   }
 
   it should "return a DecodeFailure if it can't decode an enum type" in {

--- a/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
+++ b/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
@@ -1,6 +1,7 @@
 package argus.macros
 
 import java.io.File
+import java.time.ZonedDateTime
 import java.util.UUID
 
 import argus.json.JsonDiff
@@ -9,8 +10,6 @@ import org.scalatest.{FlatSpec, Matchers}
 import cats.syntax.either._
 import io.circe._
 import io.circe.syntax._
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
 
 import scala.io.Source
 
@@ -312,7 +311,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
     root.id should === (Some(UUID.fromString(uuid)))
   }
 
-  it should "encode DateTime type" in {
+  it should "encode ZonedDateTime type" in {
     @fromSchemaJson("""
     {
       "type": "object",
@@ -329,9 +328,8 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
     import Foo.Implicits._
     import io.circe.syntax._
 
-
-    val dateTime = "2017-01-01T10:00:00.000Z"
-    val root = Root(Some(DateTime.parse(dateTime)))
+    val dateTime = "2017-01-01T10:00:00.001Z"
+    val root = Root(Some(ZonedDateTime.parse(dateTime)))
     root.asJson should beSameJsonAs (s"""
                                         |{
                                         |  "createdAt": "$dateTime"
@@ -339,7 +337,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
                                      """.stripMargin)
   }
 
-  it should "decode DateTime type" in {
+  it should "decode ZonedDateTime type" in {
     @fromSchemaJson("""
     {
       "type": "object",
@@ -355,7 +353,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
     import Foo._
     import Foo.Implicits._
 
-    val dateTime = "2017-01-01T10:00:00.000Z"
+    val dateTime = "2017-01-01T10:00:00.001Z"
     val json =
       s"""
          |{
@@ -364,7 +362,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
       """.stripMargin
     val root = parser.decode[Root](json).toOption.get
 
-    root.createdAt should === (Some(DateTime.parse(dateTime)))
+    root.createdAt should === (Some(ZonedDateTime.parse(dateTime)))
   }
 
   it should "return an error on decoding for datetime with wrong format" in {
@@ -394,7 +392,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
 
     root should be ('left)
     root.left.get match {
-      case d: DecodingFailure => d.message should === ("Invalid format: \"wrongDateTime\"")
+      case d: DecodingFailure => d.getMessage should === ("ZonedDateTime: DownField(createdAt)")
       case e@_ => fail(s"Wrong error type: ${e.getClass.getName}")
     }
   }

--- a/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
+++ b/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
@@ -331,7 +331,6 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
 
 
     val dateTime = "2017-01-01T10:00:00.000Z"
-    val uuid = "38400000-8cf0-11bd-b23e-10b96e4ef00d"
     val root = Root(Some(DateTime.parse(dateTime)))
     root.asJson should beSameJsonAs (s"""
                                         |{

--- a/argus/src/test/scala/argus/macros/ModelBuilderSpec.scala
+++ b/argus/src/test/scala/argus/macros/ModelBuilderSpec.scala
@@ -33,6 +33,7 @@ class ModelBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
 
   it should "create types with format for string type" in {
     mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.Uuid)) should === (tq"java.util.UUID")
+    mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.DateTime)) should === (tq"org.joda.time.DateTime")
   }
 
   it should "create types with unknown or incompatible formats" in {

--- a/argus/src/test/scala/argus/macros/ModelBuilderSpec.scala
+++ b/argus/src/test/scala/argus/macros/ModelBuilderSpec.scala
@@ -33,7 +33,7 @@ class ModelBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
 
   it should "create types with format for string type" in {
     mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.Uuid)) should === (tq"java.util.UUID")
-    mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.DateTime)) should === (tq"org.joda.time.DateTime")
+    mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.DateTime)) should === (tq"java.time.ZonedDateTime")
   }
 
   it should "create types with unknown or incompatible formats" in {

--- a/argus/src/test/scala/argus/macros/ModelBuilderSpec.scala
+++ b/argus/src/test/scala/argus/macros/ModelBuilderSpec.scala
@@ -12,10 +12,34 @@ class ModelBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
   import argus.schema.Schema._
 
   "mkIntriniscType()" should "create types for basic types" in {
-    mb.mkIntrinsicType(SimpleTypes.String) should === (tq"String")
-    mb.mkIntrinsicType(SimpleTypes.Boolean) should === (tq"Boolean")
-    mb.mkIntrinsicType(SimpleTypes.Integer) should === (tq"Int")
-    mb.mkIntrinsicType(SimpleTypes.Number) should === (tq"Double")
+    mb.mkIntrinsicType(SimpleTypes.String, None) should === (tq"String")
+    mb.mkIntrinsicType(SimpleTypes.Boolean, None) should === (tq"Boolean")
+    mb.mkIntrinsicType(SimpleTypes.Integer, None) should === (tq"Int")
+    mb.mkIntrinsicType(SimpleTypes.Number, None) should === (tq"Double")
+    mb.mkIntrinsicType(SimpleTypes.Null, None) should === (tq"Null")
+  }
+
+  it should "create types with format for integer type" in {
+    mb.mkIntrinsicType(SimpleTypes.Integer, Some(Formats.Int64)) should === (tq"Long")
+    mb.mkIntrinsicType(SimpleTypes.Integer, Some(Formats.Int32)) should === (tq"Int")
+    mb.mkIntrinsicType(SimpleTypes.Integer, Some(Formats.Int16)) should === (tq"Short")
+    mb.mkIntrinsicType(SimpleTypes.Integer, Some(Formats.Int8)) should === (tq"Byte")
+  }
+
+  it should "create types with format for number type" in {
+    mb.mkIntrinsicType(SimpleTypes.Number, Some(Formats.Double)) should === (tq"Double")
+    mb.mkIntrinsicType(SimpleTypes.Number, Some(Formats.Single)) should === (tq"Float")
+  }
+
+  it should "create types with unknown or incompatible formats" in {
+    mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.Int64)) should === (tq"String")
+    mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.Unknown)) should === (tq"String")
+    mb.mkIntrinsicType(SimpleTypes.Boolean, Some(Formats.Int64)) should === (tq"Boolean")
+    mb.mkIntrinsicType(SimpleTypes.Boolean, Some(Formats.Unknown)) should === (tq"Boolean")
+    mb.mkIntrinsicType(SimpleTypes.Integer, Some(Formats.Double)) should === (tq"Int")
+    mb.mkIntrinsicType(SimpleTypes.Integer, Some(Formats.Unknown)) should === (tq"Int")
+    mb.mkIntrinsicType(SimpleTypes.Number, Some(Formats.Int64)) should === (tq"Double")
+    mb.mkIntrinsicType(SimpleTypes.Number, Some(Formats.Unknown)) should === (tq"Double")
   }
 
   "mkCaseClassDef()" should "create a case class with an optional field for each simple type" in {
@@ -366,5 +390,4 @@ class ModelBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
     code should include ("case class Root(a: Option[Int] = None, b: Option[Root.C] = None)")
     code should include ("type C = String")
   }
-
 }

--- a/argus/src/test/scala/argus/macros/ModelBuilderSpec.scala
+++ b/argus/src/test/scala/argus/macros/ModelBuilderSpec.scala
@@ -31,6 +31,10 @@ class ModelBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
     mb.mkIntrinsicType(SimpleTypes.Number, Some(Formats.Single)) should === (tq"Float")
   }
 
+  it should "create types with format for string type" in {
+    mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.Uuid)) should === (tq"java.util.UUID")
+  }
+
   it should "create types with unknown or incompatible formats" in {
     mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.Int64)) should === (tq"String")
     mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.Unknown)) should === (tq"String")

--- a/argus/src/test/scala/argus/schema/SchemaSpec.scala
+++ b/argus/src/test/scala/argus/schema/SchemaSpec.scala
@@ -53,4 +53,51 @@ class SchemaSpec extends FlatSpec with Matchers {
     pending
   }
 
+  it should "decode int64 format" in {
+    val json =
+      """
+        |{
+        |  "type" : "object",
+        |  "properties": {
+        |    "age": {
+        |      "type": "integer",
+        |      "format": "int64"
+        |     }
+        |  }
+        |}
+      """.stripMargin
+    val schema = Schema.fromJson(json)
+
+    val ageFormat = for {
+      props <- schema.properties
+      country <- props.find(_.name == "age")
+      enum <- country.schema.format
+    } yield enum
+
+    ageFormat should === (Some(Formats.Int64))
+  }
+
+  it should "decode unknown format" in {
+    val json =
+      """
+        |{
+        |  "type" : "object",
+        |  "properties": {
+        |    "age": {
+        |      "type": "integer",
+        |      "format": "color"
+        |     }
+        |  }
+        |}
+      """.stripMargin
+    val schema = Schema.fromJson(json)
+
+    val ageFormat = for {
+      props <- schema.properties
+      country <- props.find(_.name == "age")
+      enum <- country.schema.format
+    } yield enum
+
+    ageFormat should === (Some(Formats.Unknown))
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,16 @@
 import ReleaseTransformations._
 
 lazy val Vers = new {
-  val circe = "0.7.0"
+  val circe = "0.8.0"
   val scalatest = "3.0.1"
-  val jodaTime = "2.9.9"
 }
 
 lazy val commonSettings = Seq(
   name := "Argus",
   organization := "com.github.aishfenton",
-  scalaVersion := "2.12.1",
-  crossScalaVersions := Seq("2.11.8", "2.12.1"),
-  scalacOptions += "-target:jvm-1.7",
+  scalaVersion := "2.12.2",
+  crossScalaVersions := Seq("2.11.11", "2.12.2"),
+  scalacOptions += "-target:jvm-1.8",
   homepage := Some(url("https://github.com/aishfenton/Argus")),
   licenses := Seq("MIT License" -> url("http://www.opensource.org/licenses/MIT")),
 
@@ -90,8 +89,7 @@ lazy val argus = project.
       "io.circe" %% "circe-core" % Vers.circe,
       "io.circe" %% "circe-generic" % Vers.circe,
       "io.circe" %% "circe-parser" % Vers.circe,
-
-      "joda-time" % "joda-time" % Vers.jodaTime,
+      "io.circe" %% "circe-java8" % Vers.circe,
 
       "org.scalactic" %% "scalactic" % Vers.scalatest % Test,
       "org.scalatest" %% "scalatest" % Vers.scalatest % Test

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,7 @@ import ReleaseTransformations._
 lazy val Vers = new {
   val circe = "0.7.0"
   val scalatest = "3.0.1"
+  val jodaTime = "2.9.9"
 }
 
 lazy val commonSettings = Seq(
@@ -89,6 +90,8 @@ lazy val argus = project.
       "io.circe" %% "circe-core" % Vers.circe,
       "io.circe" %% "circe-generic" % Vers.circe,
       "io.circe" %% "circe-parser" % Vers.circe,
+
+      "joda-time" % "joda-time" % Vers.jodaTime,
 
       "org.scalactic" %% "scalactic" % Vers.scalatest % Test,
       "org.scalatest" %% "scalatest" % Vers.scalatest % Test


### PR DESCRIPTION
Support formats:
* int64 -> Long
* int32 -> Int
* int16 -> Short
* int8 -> Byte
* single -> Float
* double -> Double
* uuid -> java.util.UUID
* date-time -> org.joda.time.DateTime