### PR TITLE
Add codePrefix option for generated code

### DIFF
--- a/argus/src/main/scala/argus/macros/FromSchema.scala
+++ b/argus/src/main/scala/argus/macros/FromSchema.scala
@@ -68,7 +68,7 @@ class SchemaMacros(val c: Context) {
   private val helpers = new ASTHelpers[c.universe.type](c.universe)
   import helpers._
 
-  case class Params(schema: Schema.Root, debug: Boolean, jsonEnd: Option[JsonEng], outPath: Option[String], name: String)
+  case class Params(schema: Schema.Root, debug: Boolean, jsonEnd: Option[JsonEng], outPath: Option[String], name: String, codePrefix: Option[String])
 
   private def extractParams(prefix: Tree): Params = {
     val q"new $name (..$paramASTs)" = prefix
@@ -104,9 +104,10 @@ class SchemaMacros(val c: Context) {
     )
   }
 
-  private def saveToFile(path: String, tree: Tree) = {
+  private def saveToFile(path: String, tree: Tree, codePrefix: Option[String]) = {
     // Clean up the code a little to make it more readable
-    val code = showCode(tree)
+    val code = codePrefix.getOrElse("")
+      + showCode(tree)
       .replaceAll(",", ",\n")
       .replaceAll("\\.flatMap", "\n.flatMap")
 
@@ -162,7 +163,7 @@ class SchemaMacros(val c: Context) {
 
     if (params.debug) println(showCode(result))
 
-    params.outPath match { case Some(path) => saveToFile(path, result); case None => /* noop */ }
+    params.outPath match { case Some(path) => saveToFile(path, result, params.codePrefix); case None => /* noop */ }
 
     c.Expr[Any](result)
   }


### PR DESCRIPTION
Until IntelliJ macro support is added, the outPath option can be used to save the code to a file in order to allow intellisense support in the IDE. However, the code written to outPath doesn't have any package prefix, and so it won't be handled correctly by the IDE unless the model happens to be in the root package.

This PR adds a "codePrefix" option that allows the used to specify some arbitrary code to be prepended to the generated code so that they can insert a package declaration.