### PR TITLE
Create default parameter values for enums that only have a single case

### DIFF
--- a/argus/src/main/scala/argus/macros/ModelBuilder.scala
+++ b/argus/src/main/scala/argus/macros/ModelBuilder.scala
@@ -45,7 +45,13 @@ class ModelBuilder[U <: Universe](val u: U) {
       // If required, then don't wrap in Option
       val optional = !requiredFields.getOrElse(Nil).contains(field.name)
 
-      val (valDef, defDef) = mkValDef(path :+ name, field, optional)
+      val enums = field.schema.enum.getOrElse(List())
+      val defval: Option[Select] = if (enums.length == 1) 
+          Some(enumName(name, field.name, enums.head))
+        else 
+          None
+
+      val (valDef, defDef) = mkValDef(path :+ name, field, optional, defval)
       (valDefs :+ valDef, defDefs ++ defDef)
     }
 
@@ -81,6 +87,13 @@ class ModelBuilder[U <: Universe](val u: U) {
     val defs = baseDef :: q"""object ${TermName(baseName + "Enums")} { ..$memberDefs }""" :: Nil
 
     (typ, defs)
+  }
+
+  /**
+    * The fully-qualified name of an enum case.
+    */
+  def enumName(ownerName: String, fieldName: String, caseName: String): Select = {
+    Select(Select(Ident(TermName(ownerName)), TermName(fieldName.capitalize + "Enums")), TermName(nameFromJson(caseName)))
   }
 
   /**
@@ -270,15 +283,19 @@ class ModelBuilder[U <: Universe](val u: U) {
     * Makes a value definition (e.g. val i: Int). These are used for constructing parameter lists
     * and declaring local objects
     */
-  def mkValDef(path: List[String], field: Field, optional: Boolean): (ValDef, List[Tree]) = {
+  def mkValDef(path: List[String], field: Field, optional: Boolean, defval: Option[Select] = None): (ValDef, List[Tree]) = {
     val schema = field.schema
 
     val (typ, defs) = mkType(path, schema, field.name.capitalize)
 
     val valDef = (if (optional) {
-      q"val ${TermName(field.name)}: ${inOption(typ)} = None"
+      val dval = defval.map({ x => q"Some(${x})" }).getOrElse(q"None")
+      q"val ${TermName(field.name)}: ${inOption(typ)} = ${dval}"
     } else {
-      q"val ${TermName(field.name)}: $typ"
+      defval match {
+        case None => q"val ${TermName(field.name)}: ${typ}"
+        case Some(dval) => q"val ${TermName(field.name)}: ${typ} = ${dval}"
+      }
     }).asInstanceOf[ValDef]
 
     (valDef, defs)


### PR DESCRIPTION
Enums with a single value are a common way to create a discriminator field to distinguish between different possible oneOf values, especially in cases when all the other fields of the possible cases are not required. This PR causes the generator to check whether a required enum field has only a single possible case, and thereby causes the case class' parameter default to the single enum case, since it can't possibly be anything else. This simplifies the client code for generating enum cases, so that instead of doing:

`var owner = Root(pet = Cat(species = Cat.SpeciesEnums.Cat))`

You can just do:

`var owner = Root(pet = Cat())`
