### PR TITLE
Updates to circe 0.11.1

### DIFF
--- a/argus/src/main/scala/argus/macros/CirceCodecBuilder.scala
+++ b/argus/src/main/scala/argus/macros/CirceCodecBuilder.scala
@@ -55,7 +55,7 @@ class CirceCodecBuilder[U <: Universe](val u: U) extends CodecBuilder {
       case b if b.isBoolean => b.as[Boolean]
       case s if s.isString =>  s.as[String]
       case o if o.isObject =>  o.as[Map[String, Any]](Decoder.decodeMapLike(KeyDecoder.decodeKeyString, anyDecoder, Map.canBuildFrom))
-      case a if a.isArray =>   a.as[List[Any]](Decoder.decodeTraversable(anyDecoder, List.canBuildFrom[Any]))
+      case a if a.isArray =>   a.as[List[Any]](Decoder.decodeIterable(anyDecoder, List.canBuildFrom[Any]))
     })
   """
 

--- a/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
+++ b/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
@@ -436,7 +436,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
 
     root should be ('left)
     root.left.get match {
-      case d: DecodingFailure => d.getMessage should === ("ZonedDateTime: DownField(createdAt)")
+      case d: DecodingFailure => d.getMessage should === ("ZonedDateTime (Text 'wrongDateTime' could not be parsed at index 0): DownField(createdAt)")
       case e@_ => fail(s"Wrong error type: ${e.getClass.getName}")
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import ReleaseTransformations._
 
 lazy val Vers = new {
-  val circe = "0.9.0"
+  val circe = "0.11.1"
   val scalatest = "3.0.1"
 }
 


### PR DESCRIPTION
Just an update from 0.9.0 to 0.11.1 for `circe`. 
- `decodeTraversable` was replaced in circe with `decodeIterable`
- The only failing test in `FromSchemaSpec` was fixed by fixing the expected error message.